### PR TITLE
Changed multiplication order in error covariance matrix

### DIFF
--- a/kalmann/knn.py
+++ b/kalmann/knn.py
@@ -259,7 +259,7 @@ class KNN:
         dW = step*K.dot(y-h)
         self.W[0] = self.W[0] + dW[:self.W[0].size].reshape(self.W[0].shape)
         self.W[1] = self.W[1] + dW[self.W[0].size:].reshape(self.W[1].shape)
-        self.P = self.P - K.dot(H).dot(self.P)
+        self.P = self.P - np.dot(K, H.dot(self.P))
         if self.Q_nonzero: self.P = self.P + self.Q
 
 ####


### PR DESCRIPTION
Hey @jnez71 ,

Thanks for your implementation. I was having a look at your code and there is a chance to gain some major speedup by computing the update of the error covariance matrix differently.

Assuming _K_ is of size _m x n_, _H_ of size _n x m_ and _P_ of size _m x m_.
Then your are running _n*m^2+m^3_ multiplications [here](https://github.com/jnez71/kalmaNN/blob/e191ed3b8d6492629b6c8432985e98300eb90ae3/kalmann/knn.py#L262).

Changing this to `self.P = self.P - np.dot(K, H.dot(self.P))` and you are only running _2*m^2 * n_ multiplications.

This will lead to (major) performance improvements if _m>>n_, which is usually the case. In your last demo script (_3d_dynamic.py_), where you are looking at a single hidden layer with 20 nodes, the speed-up is already around 26%.
If you discuss bigger networks, say number of weights is around 40, the speedup is already around 45%.